### PR TITLE
Add support for Activity.defineTask

### DIFF
--- a/src/DurableFunctions.FSharp/Activity.fs
+++ b/src/DurableFunctions.FSharp/Activity.fs
@@ -24,6 +24,12 @@ module Activity =
         run = fun x -> f x |> Async.StartAsTask
     }
 
+    /// Constructor of activity given its name and a function returning Task<'a>.
+    let defineTask (name: string) run = {
+        name = name
+        run = run
+    }    
+
     /// Runs the activity
     let run activity = activity.run
 


### PR DESCRIPTION
I could have used the record intializer directly but without looking at the source it wasn't clear from the examples. So this adds the same overload that is used in the examples but for `Tasks`