### PR TITLE
Document Exponential Backoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,20 @@ let workflow = orchestrator {
 }
 ```
 
+This will result in a maximum of 6 attempts, the initial attempt and up to 5 retries attempts. For the purpose of selecting appropriate parameters list of delays as well as the maximum delay can be calculated with ([implementation](https://github.com/Azure/durabletask/blob/61a2dc2f94cfa0aa2aae6ceb080717bad8a616b8/src/DurableTask.Core/RetryInterceptor.cs#L81)):
+
+``` 
+open System
+
+let MaxNumberOfAttempts = 5
+let FirstRetryInterval = TimeSpan.FromSeconds 1.
+let BackoffCoefficient = 2.
+
+let nthDelay n = FirstRetryInterval.TotalMilliseconds * (Math.Pow(BackoffCoefficient, float n))
+let allDelays = seq { for n in 0 .. (MaxNumberOfAttempts - 1) do yield nthDelay n } |> Seq.toList
+let totalDelay = allDelays |> List.sum
+``` 
+
 See [the full example](https://github.com/mikhailshilkov/DurableFunctions.FSharp/blob/master/samples/Retry.fs).
 
 Waiting For External Events


### PR DESCRIPTION
When selecting parameters I could not find any documentation for the how to generate the retry sequence. Asking on StackOverflow I got this answer https://stackoverflow.com/questions/55736973/how-is-the-next-retry-time-calculated-for-durable-functions-when-there-is-a-back/55753679#55753679

If you would rather see nthDelay, allDelays and totalDelay as code, perhaps members of RetryPolicy let me know?