### PR TITLE
Document some limits on activity function params

### DIFF
--- a/samples/Parameters.fs
+++ b/samples/Parameters.fs
@@ -1,4 +1,14 @@
-﻿module samples.InputParameter
+(*  
+Example demonstrating how to pass a strongly typed parameter to an activity funciton, in this case 
+a string parsed from the query string by HttpStart. 
+
+NOTE: Because durable functions maintain their state in Azure Storage the parameters must be 
+serializable by vanilla Json.Net serialization. Basic types classses and F# records are supported.
+Some types such as F# tuples are not. If you use an unsuppored type your code may compile but at 
+runtime the DurableFunctions library will indicate the given actiivyt function can't be found.
+*)
+
+module samples.InputParameter
 
 open Microsoft.Azure.WebJobs
 open DurableFunctions.FSharp


### PR DESCRIPTION
Adds documentation pointing out some F# types can't be used as parameters to Activity Functions.