### PR TITLE
Attempt to add TryWith to Orch CE

### DIFF
--- a/samples/ErrorHandling.fs
+++ b/samples/ErrorHandling.fs
@@ -1,0 +1,28 @@
+module samples.ErrorHandling
+
+open Microsoft.Azure.WebJobs
+open DurableFunctions.FSharp
+open System
+
+let failIfJam = 
+    let work name =
+        if name = "Jam" then failwith "No Jam"
+        else sprintf "Hi %s" name
+    Activity.define "FailIfJam" work
+
+let workflow = orchestrator {
+    try
+        return! Activity.call failIfJam "Jam"
+    with _ ->
+        try
+            return! Activity.call failIfJam "John"
+        with
+        | exn -> return exn.ToString()
+}
+
+[<FunctionName("FailIfJam")>]
+let Fail([<ActivityTrigger>] name) = failIfJam.run name
+
+[<FunctionName("ErrorHandlingWorkflow")>]
+let Run ([<OrchestrationTrigger>] context: DurableOrchestrationContext) =
+    Orchestrator.run (workflow, context)

--- a/samples/ErrorHandling.fs
+++ b/samples/ErrorHandling.fs
@@ -10,7 +10,7 @@ let failIfJam =
         else sprintf "Hi %s" name
     Activity.define "FailIfJam" work
 
-let workflow = orchestrator {
+let tryWithFlow = orchestrator {
     try
         return! Activity.call failIfJam "Jam"
     with _ ->
@@ -20,9 +20,20 @@ let workflow = orchestrator {
         | exn -> return exn.ToString()
 }
 
+let tryFinallyFlow name = orchestrator {
+    try
+        return! Activity.call failIfJam name
+    finally
+        printfn "*** Buy %s! THIS WILL ALWAYS BE EXECUTED ***" name
+}
+
 [<FunctionName("FailIfJam")>]
 let Fail([<ActivityTrigger>] name) = failIfJam.run name
 
-[<FunctionName("ErrorHandlingWorkflow")>]
-let Run ([<OrchestrationTrigger>] context: DurableOrchestrationContext) =
-    Orchestrator.run (workflow, context)
+[<FunctionName("TryWithWorkflow")>]
+let RunWith ([<OrchestrationTrigger>] context: DurableOrchestrationContext) =
+    Orchestrator.run (tryWithFlow, context)
+
+[<FunctionName("TryFinallyWorkflow")>]
+let RunFinally ([<OrchestrationTrigger>] context: DurableOrchestrationContext) =
+    Orchestrator.run (tryFinallyFlow, context)

--- a/samples/Retry.fs
+++ b/samples/Retry.fs
@@ -35,8 +35,19 @@ let workflow = orchestrator {
     let policy = ExponentialBackOff { MaxNumberOfAttempts = 5
                                       FirstRetryInterval = TimeSpan.FromSeconds 1.
                                       BackoffCoefficient = 2. }
-    let! msg = Activity.callWithRetries policy failUntil3 "Jam"
-    return msg
+
+    // In this case the exeption will propogate out of the workflow causing the 
+    // orchestration to fail.
+    //let! msg = Activity.callWithRetries policy failUntil3 "Jam"
+    //return msg
+
+     //Catch any exceptions in the activity function. Without this the exception
+     //will propogate causing the orchestrator to fail.
+    try 
+        let! msg = Activity.callWithRetries policy failUntil3 "Jam"
+        return msg
+    with ex -> 
+        return "error"
 }
 
 [<FunctionName("FailUntil3")>]

--- a/samples/Retry.fs
+++ b/samples/Retry.fs
@@ -35,19 +35,8 @@ let workflow = orchestrator {
     let policy = ExponentialBackOff { MaxNumberOfAttempts = 5
                                       FirstRetryInterval = TimeSpan.FromSeconds 1.
                                       BackoffCoefficient = 2. }
-
-    // In this case the exeption will propogate out of the workflow causing the 
-    // orchestration to fail.
-    //let! msg = Activity.callWithRetries policy failUntil3 "Jam"
-    //return msg
-
-     //Catch any exceptions in the activity function. Without this the exception
-     //will propogate causing the orchestrator to fail.
-    try 
-        let! msg = Activity.callWithRetries policy failUntil3 "Jam"
-        return msg
-    with ex -> 
-        return "error"
+    let! msg = Activity.callWithRetries policy failUntil3 "Jam"
+    return msg
 }
 
 [<FunctionName("FailUntil3")>]

--- a/samples/samples.fsproj
+++ b/samples/samples.fsproj
@@ -12,6 +12,7 @@
     <Compile Include="FanOutFanIn.fs" />
     <Compile Include="Delay.fs" />
     <Compile Include="HttpStart.fs" />
+    <Compile Include="Retry.fs" />
   </ItemGroup>
 
   <ItemGroup>
@@ -27,6 +28,10 @@
     <Content Include="local.settings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\DurableFunctions.FSharp\DurableFunctions.FSharp.fsproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/samples.fsproj
+++ b/samples/samples.fsproj
@@ -11,8 +11,10 @@
     <Compile Include="Parameters.fs" />
     <Compile Include="FanOutFanIn.fs" />
     <Compile Include="Delay.fs" />
-    <Compile Include="HttpStart.fs" />
+    <Compile Include="WaitForEvent.fs" />
     <Compile Include="Retry.fs" />
+    <Compile Include="ErrorHandling.fs" />
+    <Compile Include="HttpStart.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DurableFunctions.FSharp/OrchestratorCE.fs
+++ b/src/DurableFunctions.FSharp/OrchestratorCE.fs
@@ -150,7 +150,7 @@ module OrchestratorBuilder =
 
     /// Wraps a step in a try/with. This catches exceptions both in the evaluation of the function
     /// to retrieve the step, and in the continuation of the step (if any).
-    let rec tryWith (step : unit -> Step<'a>) (catch : exn -> Step<'a>) =
+    let rec tryWith(step : unit -> Step<'a>) (catch : exn -> Step<'a>) =
         try
             match step() with
             | Return _ as i -> i
@@ -169,6 +169,43 @@ module OrchestratorBuilder =
         with
         | exn -> catch exn
 
+    /// Wraps a step in a try/finally. This catches exceptions both in the evaluation of the function
+    /// to retrieve the step, and in the continuation of the step (if any).
+    let rec tryFinally (step : unit -> Step<'a>) fin =
+        let step =
+            try step()
+            // Important point: we use a try/with, not a try/finally, to implement tryFinally.
+            // The reason for this is that if we're just building a continuation, we definitely *shouldn't*
+            // execute the `fin()` part yet -- the actual execution of the asynchronous code hasn't completed!
+            with
+            | _ ->
+                fin()
+                reraise()
+        match step with
+        | Return _ as i ->
+            fin()
+            i
+        | ReturnFrom task ->
+            let wrapper ctx =
+                let awaitable = (task ctx).GetAwaiter()
+                let step = 
+                    Await(awaitable, fun () ->
+                        let result =
+                            try
+                                awaitable.GetResult() |> Return
+                            with
+                            | _ ->
+                                fin()
+                                reraise()
+                        fin() // if we got here we haven't run fin(), because we would've reraised after doing so
+                        result)
+                StepStateMachine<'a>(step, ctx).Run().Unwrap()
+            ReturnFrom wrapper
+
+        | Await (awaitable, next) ->
+            Await (awaitable, fun () -> tryFinally next fin)
+
+
     /// Builds a `System.Threading.Tasks.Task<'a>` similarly to a C# async/await method, but with
     /// all awaited tasks automatically configured *not* to resume on the captured context.
     /// This is often preferable when writing library code that is not context-aware, but undesirable when writing
@@ -181,8 +218,9 @@ module OrchestratorBuilder =
         member inline __.Zero() = zero
         member inline __.Return(x) = ret x
         member inline __.ReturnFrom(task : ContextTask<'a>) = ReturnFrom task
-        member inline __.Combine(step : unit Step, continuation) = combine step continuation
+        member inline __.Combine(step : Step<unit>, continuation) = combine step continuation
         member inline __.TryWith(task : unit -> Step<'a>, handler : exn -> Step<'a>) = tryWith task handler
+        member inline __.TryFinally(task : unit -> Step<'a>, fin : unit -> unit) = tryFinally task fin
         member inline __.Using(disp : #IDisposable, body : #IDisposable -> _ Step) = using disp body
 
         // We have to have a dedicated overload for Task<'a> so the compiler doesn't get confused.


### PR DESCRIPTION
Main change is to add `TryWith` to the Builder. This is to address https://github.com/mikhailshilkov/DurableFunctions.FSharp/issues/9. Unfortunately the implementation does not work. The `try` block is entered but the "boom" is never caught by the `with`. I think this is because the `ReturnFrom t` simply returns the `step` but does not execute it. 

I don't know where to got from here. 

![image](https://user-images.githubusercontent.com/4968704/57571997-fc4c7280-73c9-11e9-83cc-16edd2c0136c.png)

Minor changes
* Adds Reply.fs to the samples project
* Adds the Durablefunctions.FSharp project as a dependancy of the samples project. This makes it easier to test changes.
