### PR TITLE
Add Call by name with retries to activity

### DIFF
--- a/src/DurableFunctions.FSharp/Activity.fs
+++ b/src/DurableFunctions.FSharp/Activity.fs
@@ -66,6 +66,19 @@ module Activity =
                 r
         c.CallActivityWithRetryAsync<'b> (activity.name, options, arg)
 
+    /// Call the activity by name passing an object as its input argument
+    /// and specifying the type to expect for the activity output. Apply retry
+    /// policy in case of call failure(s).
+    let callByNameWithRetries<'a> (policy: RetryPolicy) (name:string) arg (c: DurableOrchestrationContext) =
+        let options = 
+            match policy with
+            | ExponentialBackOff e ->
+                        let r = RetryOptions(firstRetryInterval = e.FirstRetryInterval,
+                                                maxNumberOfAttempts = e.MaxNumberOfAttempts)
+                        r.BackoffCoefficient <- e.BackoffCoefficient
+                        r
+        c.CallActivityWithRetryAsync<'a> (name, options, arg)
+
     /// Call all specified tasks in parallel and combine the results together. To be used
     /// for fan-out / fan-in pattern of parallel execution.
     let all (tasks: OrchestratorBuilder.ContextTask<'a> seq) = orchestrator {


### PR DESCRIPTION
I wanted to use the recent dependency injection supported in Azure Functions - that meant adding my functions as members to a type - with that type receiving dependencies via construction injection.
As a consequence I couldn't find a nice way to use typed activities so ended up using the callByName function - in order to also use retry policies I needed to add a suitable function to Activity