### PR TITLE
Make unit testing possible by switching to base context

### DIFF
--- a/samples/Eternal.fs
+++ b/samples/Eternal.fs
@@ -4,18 +4,17 @@ open System
 open Microsoft.Azure.WebJobs
 open DurableFunctions.FSharp
 
-let printTime = 
-    fun (d: DateTime) -> sprintf "Printing at %s!" (d.ToShortTimeString())
-    |> Activity.define "PrintTime"
+let printTime =     
+    Activity.define "PrintTime" (fun (d: DateTime) -> sprintf "Printing at %s!" (d.ToShortTimeString()))
 
 let workflow = orchestrator {
-    let! s = Activity.call printTime DateTime.Now
+    let! (s:string) = Activity.call printTime DateTime.Now
     do! Orchestrator.delay (TimeSpan.FromSeconds 5.0)
     return if s.Contains "00" then Stop else ContinueAsNew ()
 }
 
 let workflowWithParam delay = orchestrator {
-    let! s = Activity.call printTime DateTime.Now
+    let! (s:string) = Activity.call printTime DateTime.Now
     do! Orchestrator.delay (TimeSpan.FromSeconds delay)
     return if s.Contains "00" then Stop else ContinueAsNew (delay + 1.)
 }

--- a/samples/Hello.fs
+++ b/samples/Hello.fs
@@ -7,10 +7,7 @@ open DurableFunctions.FSharp
 let SayHello([<ActivityTrigger>] name) = 
     sprintf "Hello %s!" name
 
-[<FunctionName("HelloSequence")>]
-let Run ([<OrchestrationTrigger>] context: DurableOrchestrationContext) = 
-    context |>    
-    orchestrator {
+let workflow = orchestrator {
       let! hello1 = Activity.callByName<string> "SayHello" "Tokyo"
       let! hello2 = Activity.callByName<string> "SayHello" "Seattle"
       let! hello3 = Activity.callByName<string> "SayHello" "London"
@@ -18,3 +15,8 @@ let Run ([<OrchestrationTrigger>] context: DurableOrchestrationContext) =
       // returns ["Hello Tokyo!", "Hello Seattle!", "Hello London!"]
       return [hello1; hello2; hello3]
     }
+
+[<FunctionName("HelloSequence")>]
+let Run ([<OrchestrationTrigger>] context: DurableOrchestrationContext) = 
+    Orchestrator.run (workflow, context)  
+    

--- a/samples/samples.fsproj
+++ b/samples/samples.fsproj
@@ -16,12 +16,15 @@
     <Compile Include="ErrorHandling.fs" />
     <Compile Include="Eternal.fs" />
     <Compile Include="HttpStart.fs" />
+    <Compile Include="testing.fs" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.27" />
     <PackageReference Include="DurableFunctions.FSharp" Version="0.3.1" />
     <PackageReference Include="TaskBuilder.fs" Version="1.0.0" />
+    <PackageReference Include="Moq" Version="4.12.0" />
+    <PackageReference Include="Expecto" Version="8.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/testing.fs
+++ b/samples/testing.fs
@@ -1,0 +1,45 @@
+module samples.unittest
+
+open Microsoft.Azure.WebJobs
+open DurableFunctions.FSharp
+open System
+
+[<FunctionName("SayHelloTest")>]
+let SayHello([<ActivityTrigger>] name) = 
+    sprintf "Hello %s!" name
+
+[<FunctionName("HelloSequenceTest")>]
+let RunWorkflow ([<OrchestrationTrigger>] context: DurableOrchestrationContextBase) = 
+    context |>    
+    orchestrator {
+      let! hello1 = Activity.callByName<string> "SayHello" "Tokyo"
+      let! hello2 = Activity.callByName<string> "SayHello" "Seattle"
+      let! hello3 = Activity.callByName<string> "SayHello" "London"
+
+      // returns ["Hello Tokyo!", "Hello Seattle!", "Hello London!"]
+      return [hello1; hello2; hello3]
+    }
+
+module WorkflowTests =
+
+  open Moq
+  open Expecto
+  
+  
+  [<Tests>]
+  let tests = 
+          testList "orchestration tests" [
+              testAsync "Orchestration test no records" {
+                   
+                  let mockContext = Mock<DurableOrchestrationContextBase>()
+                  mockContext.Setup(fun c -> c.CallActivityAsync<string>("SayHello","Tokyo")).ReturnsAsync("Hello Tokyo") |> ignore
+                  mockContext.Setup(fun c -> c.CallActivityAsync<string>("SayHello","Seattle")).ReturnsAsync("Hello Seattle") |> ignore
+                  mockContext.Setup(fun c -> c.CallActivityAsync<string>("SayHello","London")).ReturnsAsync("Hello London") |> ignore
+                  let! results = RunWorkflow mockContext.Object |> Async.AwaitTask
+
+                  Expect.hasLength results 3 "should be 3 results"
+                  Expect.equal results.[0] "Hello Tokyo!" "Should be Hello Tokyo!"
+                  Expect.equal results.[1] "Hello Seattle!" "Should be Hello Seattle!"
+                  Expect.equal results.[2] "Hello London!" "Should be Hello London!"
+              }
+          ]

--- a/src/DurableFunctions.FSharp/Activity.fs
+++ b/src/DurableFunctions.FSharp/Activity.fs
@@ -47,11 +47,11 @@ module Activity =
 
     /// Call an activity by name, passing an object as its input argument
     /// and specifying the type to expect for the activity output.
-    let callByName<'a> (name: string) arg (c: DurableOrchestrationContext) =
+    let callByName<'a> (name: string) arg (c: DurableOrchestrationContextBase) =
         c.CallActivityAsync<'a> (name, arg)
 
     /// Call the activity with given input parameter and return its result.
-    let call (activity: Activity<'a, 'b>) (arg: 'a) (c: DurableOrchestrationContext) =
+    let call (activity: Activity<'a, 'b>) (arg: 'a) (c: DurableOrchestrationContextBase) =
         c.CallActivityAsync<'b> (activity.name, arg)
 
     let optionsBuilder = function
@@ -63,13 +63,13 @@ module Activity =
 
     /// Call the activity with given input parameter and return its result. Apply retry
     /// policy in case of call failure(s).
-    let callWithRetries (policy: RetryPolicy) (activity: Activity<'a, 'b>) (arg: 'a) (c: DurableOrchestrationContext) =
+    let callWithRetries (policy: RetryPolicy) (activity: Activity<'a, 'b>) (arg: 'a) (c: DurableOrchestrationContextBase) =
         c.CallActivityWithRetryAsync<'b> (activity.name, (optionsBuilder policy), arg)
 
     /// Call the activity by name passing an object as its input argument
     /// and specifying the type to expect for the activity output. Apply retry
     /// policy in case of call failure(s).
-    let callByNameWithRetries<'a> (policy: RetryPolicy) (name:string) arg (c: DurableOrchestrationContext) =
+    let callByNameWithRetries<'a> (policy: RetryPolicy) (name:string) arg (c: DurableOrchestrationContextBase) =
         c.CallActivityWithRetryAsync<'a> (name, (optionsBuilder policy), arg)
 
     /// Call all specified tasks in parallel and combine the results together. To be used

--- a/src/DurableFunctions.FSharp/Orchestrator.fs
+++ b/src/DurableFunctions.FSharp/Orchestrator.fs
@@ -14,12 +14,12 @@ type Orchestrator = class
 
     /// Runs a workflow which expects an input parameter by reading this parameter from 
     /// the orchestration context.
-    static member run (workflow : ContextTask<'b>, context : DurableOrchestrationContext) : Task<'b> = 
+    static member run (workflow : ContextTask<'b>, context : DurableOrchestrationContextBase) : Task<'b> = 
         workflow context
 
     /// Runs a workflow which expects an input parameter by reading this parameter from 
     /// the orchestration context.
-    static member run (workflow : 'a -> ContextTask<'b>, context : DurableOrchestrationContext) : Task<'b> = 
+    static member run (workflow : 'a -> ContextTask<'b>, context : DurableOrchestrationContextBase) : Task<'b> = 
         let input = context.GetInput<'a> ()
         workflow input context
 
@@ -27,7 +27,7 @@ type Orchestrator = class
     /// [ContinueAsNew] calls. The orchestrator will keep running until Stop command is
     /// returned from one of the workflow iterations.
     /// This overload always passes [null] to [ContinueAsNew] calls.
-    static member runEternal (workflow : ContextTask<EternalOrchestrationCommand<unit>>, context : DurableOrchestrationContext) : Task = 
+    static member runEternal (workflow : ContextTask<EternalOrchestrationCommand<unit>>, context : DurableOrchestrationContextBase) : Task = 
         let task = workflow context
         task.ContinueWith (
             fun (t: Task<EternalOrchestrationCommand<unit>>) ->
@@ -40,7 +40,7 @@ type Orchestrator = class
     /// [ContinueAsNew] calls. The orchestrator will keep running until Stop command is
     /// returned from one of the workflow iterations.
     /// This overload always passes the returned value to [ContinueAsNew] calls.
-    static member runEternal (workflow : 'a -> ContextTask<EternalOrchestrationCommand<'a>>, context : DurableOrchestrationContext) : Task = 
+    static member runEternal (workflow : 'a -> ContextTask<EternalOrchestrationCommand<'a>>, context : DurableOrchestrationContextBase) : Task = 
         let input = context.GetInput<'a> ()
         let task = workflow input context
         task.ContinueWith (
@@ -51,17 +51,17 @@ type Orchestrator = class
             )
     
     /// Returns a fixed value as a orchestrator.
-    static member ret value (_: DurableOrchestrationContext) =
+    static member ret value (_: DurableOrchestrationContextBase) =
         Task.FromResult value
 
     /// Delays orchestrator execution by the specified timespan.
-    static member delay (timespan: TimeSpan) (context: DurableOrchestrationContext) =
+    static member delay (timespan: TimeSpan) (context: DurableOrchestrationContextBase) =
         let deadline = context.CurrentUtcDateTime.Add timespan
         context.CreateTimer(deadline, CancellationToken.None)
     
     /// Wait for an external event. maxTimeToWait specifies the longest period to wait:
     /// the call will return an Error if timeout is reached.
-    static member waitForEvent<'a> (maxTimeToWait: TimeSpan) (eventName: string) (context: DurableOrchestrationContext) =
+    static member waitForEvent<'a> (maxTimeToWait: TimeSpan) (eventName: string) (context: DurableOrchestrationContextBase) =
         let deadline = context.CurrentUtcDateTime.Add maxTimeToWait
         let timer = context.CreateTimer(deadline, CancellationToken.None)
         let event = context.WaitForExternalEvent<'a> eventName


### PR DESCRIPTION
#16 First attempt - switch to using ```DurableOrchestrationContextBase``` also added a sample Expecto/ Moq unit test

Had to make a couple of changes to the existing samples which means this is probably a breaking change
In ```Eternal.fs``` I had to add a type annotation to the result of the activity call - not entirely sure why that was required