### PR TITLE
Use latest version of DurableTask library

### DIFF
--- a/samples/Delay.fs
+++ b/samples/Delay.fs
@@ -2,6 +2,7 @@
 
 open System
 open Microsoft.Azure.WebJobs
+open Microsoft.Azure.WebJobs.Extensions.DurableTask
 open DurableFunctions.FSharp
 
 let sendNewsletter =     
@@ -32,5 +33,5 @@ let newsletter = orchestrator {
 let SendNewsletter([<ActivityTrigger>] url) = Activity.run sendNewsletter url
 
 [<FunctionName("NewsletterWorkflow")>]
-let NewsletterWorkflow ([<OrchestrationTrigger>] context: DurableOrchestrationContext) =
+let NewsletterWorkflow ([<OrchestrationTrigger>] context: IDurableOrchestrationContext) =
     Orchestrator.run (newsletter, context)

--- a/samples/ErrorHandling.fs
+++ b/samples/ErrorHandling.fs
@@ -2,7 +2,7 @@ module samples.ErrorHandling
 
 open Microsoft.Azure.WebJobs
 open DurableFunctions.FSharp
-open System
+open Microsoft.Azure.WebJobs.Extensions.DurableTask
 
 let failIfJam = 
     let work name =
@@ -31,9 +31,9 @@ let tryFinallyFlow name = orchestrator {
 let Fail([<ActivityTrigger>] name) = failIfJam.run name
 
 [<FunctionName("TryWithWorkflow")>]
-let RunWith ([<OrchestrationTrigger>] context: DurableOrchestrationContext) =
+let RunWith ([<OrchestrationTrigger>] context: IDurableOrchestrationContext) =
     Orchestrator.run (tryWithFlow, context)
 
 [<FunctionName("TryFinallyWorkflow")>]
-let RunFinally ([<OrchestrationTrigger>] context: DurableOrchestrationContext) =
+let RunFinally ([<OrchestrationTrigger>] context: IDurableOrchestrationContext) =
     Orchestrator.run (tryFinallyFlow, context)

--- a/samples/Eternal.fs
+++ b/samples/Eternal.fs
@@ -2,6 +2,7 @@ module samples.Eternal
 
 open System
 open Microsoft.Azure.WebJobs
+open Microsoft.Azure.WebJobs.Extensions.DurableTask
 open DurableFunctions.FSharp
 
 let printTime = 
@@ -9,13 +10,13 @@ let printTime =
     |> Activity.define "PrintTime"
 
 let workflow = orchestrator {
-    let! s = Activity.call printTime DateTime.Now
+    let! (s: string) = Activity.call printTime DateTime.Now
     do! Orchestrator.delay (TimeSpan.FromSeconds 5.0)
     return if s.Contains "00" then Stop else ContinueAsNew ()
 }
 
 let workflowWithParam delay = orchestrator {
-    let! s = Activity.call printTime DateTime.Now
+    let! (s: string) = Activity.call printTime DateTime.Now
     do! Orchestrator.delay (TimeSpan.FromSeconds delay)
     return if s.Contains "00" then Stop else ContinueAsNew (delay + 1.)
 }
@@ -24,9 +25,9 @@ let workflowWithParam delay = orchestrator {
 let PrintTime([<ActivityTrigger>] name) = printTime.run name
 
 [<FunctionName("Eternal")>]
-let Run ([<OrchestrationTrigger>] context: DurableOrchestrationContext) =
+let Run ([<OrchestrationTrigger>] context: IDurableOrchestrationContext) =
     Orchestrator.runEternal (workflow, context)
 
 [<FunctionName("EternalWithParam")>]
-let RunWithParam ([<OrchestrationTrigger>] context: DurableOrchestrationContext) =
+let RunWithParam ([<OrchestrationTrigger>] context: IDurableOrchestrationContext) =
     Orchestrator.runEternal (workflowWithParam, context)

--- a/samples/FanOutFanIn.fs
+++ b/samples/FanOutFanIn.fs
@@ -1,6 +1,7 @@
 module samples.FanInFanOut
 
 open Microsoft.Azure.WebJobs
+open Microsoft.Azure.WebJobs.Extensions.DurableTask
 open DurableFunctions.FSharp
 
 let hardWork = 
@@ -29,5 +30,5 @@ let workflow = orchestrator {
 let HardWork([<ActivityTrigger>] name) = hardWork.run name
 
 [<FunctionName("FanInFanOut")>]
-let FanInFanOut ([<OrchestrationTrigger>] context: DurableOrchestrationContext) =
+let FanInFanOut ([<OrchestrationTrigger>] context: IDurableOrchestrationContext) =
     Orchestrator.run (workflow, context)

--- a/samples/Hello.fs
+++ b/samples/Hello.fs
@@ -1,6 +1,7 @@
 module samples.HelloSequence
 
 open Microsoft.Azure.WebJobs
+open Microsoft.Azure.WebJobs.Extensions.DurableTask
 open DurableFunctions.FSharp
 
 [<FunctionName("SayHello")>]
@@ -8,7 +9,7 @@ let SayHello([<ActivityTrigger>] name) =
     sprintf "Hello %s!" name
 
 [<FunctionName("HelloSequence")>]
-let Run ([<OrchestrationTrigger>] context: DurableOrchestrationContext) = 
+let Run ([<OrchestrationTrigger>] context: IDurableOrchestrationContext) = 
     context |>    
     orchestrator {
       let! hello1 = Activity.callByName<string> "SayHello" "Tokyo"

--- a/samples/HttpStart.fs
+++ b/samples/HttpStart.fs
@@ -3,7 +3,7 @@ namespace samples
 open System.Net.Http
 open Microsoft.Azure.WebJobs
 open Microsoft.Azure.WebJobs.Extensions.Http
-open Microsoft.Azure.WebJobs.Host
+open Microsoft.Azure.WebJobs.Extensions.DurableTask
 open Microsoft.Extensions.Logging
 open FSharp.Control.Tasks
 
@@ -12,7 +12,7 @@ module HttpStart =
   [<FunctionName("HttpStart")>]
   let RunSync
      ([<HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "orchestrators/{functionName}")>] req: HttpRequestMessage,
-      [<OrchestrationClient>] starter: DurableOrchestrationClient,
+      [<DurableClient>] starter: IDurableOrchestrationClient,
       functionName: string,
       log: ILogger) =
     task {
@@ -27,7 +27,7 @@ module HttpStart =
   [<FunctionName("HttpSyncStart")>]
   let RunAsync
      ([<HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "orchestrators/{functionName}/wait")>] req: HttpRequestMessage,
-      [<OrchestrationClient>] starter: DurableOrchestrationClient,
+      [<DurableClient>] starter: IDurableOrchestrationClient,
       functionName: string,
       log: ILogger) =
     task {

--- a/samples/Parameters.fs
+++ b/samples/Parameters.fs
@@ -11,6 +11,7 @@ runtime the DurableFunctions library will indicate the given activity function c
 module samples.InputParameter
 
 open Microsoft.Azure.WebJobs
+open Microsoft.Azure.WebJobs.Extensions.DurableTask
 open DurableFunctions.FSharp
 
 open TypedSequence
@@ -25,5 +26,5 @@ let workflow input = orchestrator {
 }
 
 [<FunctionName("WorkflowWithInputParameter")>]
-let Run ([<OrchestrationTrigger>] context: DurableOrchestrationContext) = 
+let Run ([<OrchestrationTrigger>] context: IDurableOrchestrationContext) = 
     Orchestrator.run (workflow, context)

--- a/samples/Retry.fs
+++ b/samples/Retry.fs
@@ -20,6 +20,7 @@ https://github.com/Azure/durabletask/blob/61a2dc2f94cfa0aa2aae6ceb080717bad8a616
 module samples.Retry
 
 open Microsoft.Azure.WebJobs
+open Microsoft.Azure.WebJobs.Extensions.DurableTask
 open DurableFunctions.FSharp
 open System
 
@@ -43,5 +44,5 @@ let workflow = orchestrator {
 let FailUntil3([<ActivityTrigger>] name) = failUntil3.run name
 
 [<FunctionName("RetryWorkflow")>]
-let Run ([<OrchestrationTrigger>] context: DurableOrchestrationContext) =
+let Run ([<OrchestrationTrigger>] context: IDurableOrchestrationContext) =
     Orchestrator.run (workflow, context)

--- a/samples/Typed.fs
+++ b/samples/Typed.fs
@@ -1,6 +1,7 @@
 module samples.TypedSequence
 
 open Microsoft.Azure.WebJobs
+open Microsoft.Azure.WebJobs.Extensions.DurableTask
 open DurableFunctions.FSharp
 
 let sayHello = 
@@ -19,5 +20,5 @@ let workflow = orchestrator {
 let SayHello([<ActivityTrigger>] name) = sayHello.run name
 
 [<FunctionName("TypedSequence")>]
-let Run ([<OrchestrationTrigger>] context: DurableOrchestrationContext) =
+let Run ([<OrchestrationTrigger>] context: IDurableOrchestrationContext) =
     Orchestrator.run (workflow, context)

--- a/samples/WaitForEvent.fs
+++ b/samples/WaitForEvent.fs
@@ -1,6 +1,7 @@
 module samples.WaitForEvent
 
 open Microsoft.Azure.WebJobs
+open Microsoft.Azure.WebJobs.Extensions.DurableTask
 open DurableFunctions.FSharp
 open System
 
@@ -16,5 +17,5 @@ let workflow = orchestrator {
 }
 
 [<FunctionName("WaitingWorkflow")>]
-let Run ([<OrchestrationTrigger>] context: DurableOrchestrationContext) =
+let Run ([<OrchestrationTrigger>] context: IDurableOrchestrationContext) =
     Orchestrator.run (workflow, context)

--- a/src/DurableFunctions.FSharp/Activity.fs
+++ b/src/DurableFunctions.FSharp/Activity.fs
@@ -1,8 +1,8 @@
 namespace DurableFunctions.FSharp
 
-open Microsoft.Azure.WebJobs
 open System
 open System.Threading.Tasks
+open Microsoft.Azure.WebJobs.Extensions.DurableTask
 
 /// Strongly-typed activity representation to enable type-checked orchestrator definitions.
 type Activity<'a, 'b> = {
@@ -47,11 +47,11 @@ module Activity =
 
     /// Call an activity by name, passing an object as its input argument
     /// and specifying the type to expect for the activity output.
-    let callByName<'a> (name: string) arg (c: DurableOrchestrationContext) =
+    let callByName<'a> (name: string) arg (c: IDurableOrchestrationContext) =
         c.CallActivityAsync<'a> (name, arg)
 
     /// Call the activity with given input parameter and return its result.
-    let call (activity: Activity<'a, 'b>) (arg: 'a) (c: DurableOrchestrationContext) =
+    let call (activity: Activity<'a, 'b>) (arg: 'a) (c: IDurableOrchestrationContext) =
         c.CallActivityAsync<'b> (activity.name, arg)
 
     let optionsBuilder = function
@@ -63,13 +63,13 @@ module Activity =
 
     /// Call the activity with given input parameter and return its result. Apply retry
     /// policy in case of call failure(s).
-    let callWithRetries (policy: RetryPolicy) (activity: Activity<'a, 'b>) (arg: 'a) (c: DurableOrchestrationContext) =
+    let callWithRetries (policy: RetryPolicy) (activity: Activity<'a, 'b>) (arg: 'a) (c: IDurableOrchestrationContext) =
         c.CallActivityWithRetryAsync<'b> (activity.name, (optionsBuilder policy), arg)
 
     /// Call the activity by name passing an object as its input argument
     /// and specifying the type to expect for the activity output. Apply retry
     /// policy in case of call failure(s).
-    let callByNameWithRetries<'a> (policy: RetryPolicy) (name:string) arg (c: DurableOrchestrationContext) =
+    let callByNameWithRetries<'a> (policy: RetryPolicy) (name:string) arg (c: IDurableOrchestrationContext) =
         c.CallActivityWithRetryAsync<'a> (name, (optionsBuilder policy), arg)
 
     /// Call all specified tasks in parallel and combine the results together. To be used

--- a/src/DurableFunctions.FSharp/DurableFunctions.FSharp.fsproj
+++ b/src/DurableFunctions.FSharp/DurableFunctions.FSharp.fsproj
@@ -8,7 +8,7 @@
     <Compile Include="Orchestrator.fs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="1.8.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.1.1" />
   </ItemGroup>
 
   <!-- NuGet Publishing Metadata -->

--- a/src/DurableFunctions.FSharp/Orchestrator.fs
+++ b/src/DurableFunctions.FSharp/Orchestrator.fs
@@ -3,7 +3,7 @@
 open System
 open System.Threading
 open System.Threading.Tasks
-open Microsoft.Azure.WebJobs
+open Microsoft.Azure.WebJobs.Extensions.DurableTask
 open OrchestratorBuilder
 
 /// Eternal orchestrators should return the value of this type signaling
@@ -14,12 +14,12 @@ type Orchestrator = class
 
     /// Runs a workflow which expects an input parameter by reading this parameter from 
     /// the orchestration context.
-    static member run (workflow : ContextTask<'b>, context : DurableOrchestrationContext) : Task<'b> = 
+    static member run (workflow : ContextTask<'b>, context : IDurableOrchestrationContext) : Task<'b> = 
         workflow context
 
     /// Runs a workflow which expects an input parameter by reading this parameter from 
     /// the orchestration context.
-    static member run (workflow : 'a -> ContextTask<'b>, context : DurableOrchestrationContext) : Task<'b> = 
+    static member run (workflow : 'a -> ContextTask<'b>, context : IDurableOrchestrationContext) : Task<'b> = 
         let input = context.GetInput<'a> ()
         workflow input context
 
@@ -27,7 +27,7 @@ type Orchestrator = class
     /// [ContinueAsNew] calls. The orchestrator will keep running until Stop command is
     /// returned from one of the workflow iterations.
     /// This overload always passes [null] to [ContinueAsNew] calls.
-    static member runEternal (workflow : ContextTask<EternalOrchestrationCommand<unit>>, context : DurableOrchestrationContext) : Task = 
+    static member runEternal (workflow : ContextTask<EternalOrchestrationCommand<unit>>, context : IDurableOrchestrationContext) : Task = 
         let task = workflow context
         task.ContinueWith (
             fun (t: Task<EternalOrchestrationCommand<unit>>) ->
@@ -40,7 +40,7 @@ type Orchestrator = class
     /// [ContinueAsNew] calls. The orchestrator will keep running until Stop command is
     /// returned from one of the workflow iterations.
     /// This overload always passes the returned value to [ContinueAsNew] calls.
-    static member runEternal (workflow : 'a -> ContextTask<EternalOrchestrationCommand<'a>>, context : DurableOrchestrationContext) : Task = 
+    static member runEternal (workflow : 'a -> ContextTask<EternalOrchestrationCommand<'a>>, context : IDurableOrchestrationContext) : Task = 
         let input = context.GetInput<'a> ()
         let task = workflow input context
         task.ContinueWith (
@@ -51,17 +51,17 @@ type Orchestrator = class
             )
     
     /// Returns a fixed value as a orchestrator.
-    static member ret value (_: DurableOrchestrationContext) =
+    static member ret value (_: IDurableOrchestrationContext) =
         Task.FromResult value
 
     /// Delays orchestrator execution by the specified timespan.
-    static member delay (timespan: TimeSpan) (context: DurableOrchestrationContext) =
+    static member delay (timespan: TimeSpan) (context: IDurableOrchestrationContext) =
         let deadline = context.CurrentUtcDateTime.Add timespan
         context.CreateTimer(deadline, CancellationToken.None)
     
     /// Wait for an external event. maxTimeToWait specifies the longest period to wait:
     /// the call will return an Error if timeout is reached.
-    static member waitForEvent<'a> (maxTimeToWait: TimeSpan) (eventName: string) (context: DurableOrchestrationContext) =
+    static member waitForEvent<'a> (maxTimeToWait: TimeSpan) (eventName: string) (context: IDurableOrchestrationContext) =
         let deadline = context.CurrentUtcDateTime.Add maxTimeToWait
         let timer = context.CreateTimer(deadline, CancellationToken.None)
         let event = context.WaitForExternalEvent<'a> eventName

--- a/src/DurableFunctions.FSharp/OrchestratorCE.fs
+++ b/src/DurableFunctions.FSharp/OrchestratorCE.fs
@@ -3,12 +3,12 @@ namespace DurableFunctions.FSharp
 open System
 open System.Threading.Tasks
 open System.Runtime.CompilerServices
-open Microsoft.Azure.WebJobs
+open Microsoft.Azure.WebJobs.Extensions.DurableTask
 
 module OrchestratorBuilder =
 
-    type ContextTask = DurableOrchestrationContext -> Task
-    type ContextTask<'a> = DurableOrchestrationContext -> Task<'a>
+    type ContextTask = IDurableOrchestrationContext -> Task
+    type ContextTask<'a> = IDurableOrchestrationContext -> Task<'a>
   
     /// Represents the state of a computation:
     /// either awaiting something with a continuation,
@@ -19,7 +19,7 @@ module OrchestratorBuilder =
         /// We model tail calls explicitly, but still can't run them without O(n) memory usage.
         | ReturnFrom of ContextTask<'a>
     /// Implements the machinery of running a `Step<'m, 'm>` as a task returning a continuation task.
-    and StepStateMachine<'a>(firstStep, c: DurableOrchestrationContext) as this =
+    and StepStateMachine<'a>(firstStep, c: IDurableOrchestrationContext) as this =
         let methodBuilder = AsyncTaskMethodBuilder<'a Task>()
         /// The continuation we left off awaiting on our last MoveNext().
         let mutable continuation = fun () -> firstStep
@@ -112,7 +112,7 @@ module OrchestratorBuilder =
     /// Chains together a step with its following step.
     /// Note that this requires that the first step has no result.
     /// This prevents constructs like `task { return 1; return 2; }`.
-    let rec combine (step : Step<unit>) (continuation : unit -> Step<'b>) (c: DurableOrchestrationContext) =
+    let rec combine (step : Step<unit>) (continuation : unit -> Step<'b>) (c: IDurableOrchestrationContext) =
         match step with
         | Return _ -> continuation ()
         | ReturnFrom t ->
@@ -121,7 +121,7 @@ module OrchestratorBuilder =
             Await (awaitable, fun () -> combine (next()) continuation c)
 
     /// Runs a step as a task -- with a short-circuit for immediately completed steps.
-    let run (firstStep : unit -> Step<'a>) (c: DurableOrchestrationContext) =
+    let run (firstStep : unit -> Step<'a>) (c: IDurableOrchestrationContext) =
         try
             match firstStep() with
             | Return x -> Task.FromResult(x)


### PR DESCRIPTION
As there were some breaking changes in the 2.0 release of DurableTask library, changes are needed for DurableFunctions.FSharp to work with the latest version.

I've updated the package reference and changed the code to fix the breaking changes. Those included:
- moving from `DurableOrchestrationContext` and `DurableOrchestrationClient` to `IDurableOrchestrationContext` and `IDurableOrchestrationClient`
- use `DurableClient` instead of `OrchestrationClient`
- update the namespaces

As it's a breaking change, I guess it should be released as a new version.